### PR TITLE
ci: enable dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,14 @@
+# Basic `dependabot.yml` file with
+# minimum configuration for three package managers
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary:

Closes #10 

Enable Dependabot to update our GitHub Actions and NPM packages. 

## Test Plan:

Ci should pass