### PR TITLE
ci: override page url for deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,9 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      # ${{ steps.deployment.outputs.page_url }} points to https://microsoft.github.io/react-native-macos-docs/
+      # so let's override it to our preferred URL.
+      url: https://microsoft.github.io/react-native-macos/
     runs-on: ubuntu-24.04
     needs: prepare-pages
     steps:


### PR DESCRIPTION
## Summary:

Fixes #30 

By default, GitHub Pages publishes to microsoft.github.io/react-native-macos-docs, but we want to publish to microsoft.github.io/react-native-macos. Let's override the URL in our deploy job. 

## Test Plan:

As with publish job things, merge and watch what happens. 